### PR TITLE
Prevent wall lamps from appearing in trader stock

### DIFF
--- a/1.3/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
+++ b/1.3/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
@@ -55,6 +55,7 @@
     <graphicData>
       <texPath>Things/Building/Furniture/LampStanding</texPath>
     </graphicData>
+    <tradeability>None</tradeability>
     <costList>
       <Steel>20</Steel>
     </costList>


### PR DESCRIPTION
Since VFEA_WallLampBaseA is tradeable, it matches certain TraderKindDef StockGroups such as the StockGenerator_Category BuildingsFurniture group in the vanilla Caravan_Outlander_BulkGoods. When a wall lamp is randomly generated, the game will raise an exception while opening the trade window of the merchant and the window will be empty: https://gist.github.com/HugsLibRecordKeeper/5da5a5a181a3a114ec0d9b0e93d4d1f7

Setting the Tradeability of VFEA_WallLampBaseA to None fixes the issue by preventing wall lamps from appearing in the stock of traders.